### PR TITLE
Feature: Auto save

### DIFF
--- a/src/KetcherReact.tsx
+++ b/src/KetcherReact.tsx
@@ -8,18 +8,20 @@ const structServiceProvider = new StandaloneStructServiceProvider();
 type Props = {
 	data: string;
 	onInit: (ketcher: Ketcher) => void;
+	onChange: () => void;
 };
 
-const KetcherReact = ({ data, onInit }: Props) => {
+const KetcherReact = ({ data, onInit, onChange }: Props) => {
 	return (
 		<div className="ketcher-container">
 			<Editor
-				errorHandler={(_message: string) => {}}
+				errorHandler={(_message: string) => { }}
 				staticResourcesUrl="./"
 				structServiceProvider={structServiceProvider}
 				onInit={(ketcher: Ketcher) => {
 					ketcher.setMolecule(data);
 					onInit(ketcher);
+					ketcher.editor.subscribe('change', operations => { onChange() })
 				}}
 			/>
 		</div>

--- a/src/KetcherReact.tsx
+++ b/src/KetcherReact.tsx
@@ -7,7 +7,7 @@ const structServiceProvider = new StandaloneStructServiceProvider();
 
 type Props = {
 	data: string;
-	onInit: (ketcher: Ketcher) => void;
+	onInit: (ketcher: Ketcher, subscriber: any) => void;
 	onChange: () => void;
 };
 
@@ -20,8 +20,8 @@ const KetcherReact = ({ data, onInit, onChange }: Props) => {
 				structServiceProvider={structServiceProvider}
 				onInit={(ketcher: Ketcher) => {
 					ketcher.setMolecule(data);
-					onInit(ketcher);
-					ketcher.editor.subscribe('change', operations => { onChange() })
+					const subscriber = ketcher.editor.subscribe("change", operations => { onChange() })
+					onInit(ketcher, subscriber);
 				}}
 			/>
 		</div>

--- a/src/ketView.tsx
+++ b/src/ketView.tsx
@@ -1,5 +1,5 @@
 import { Ketcher } from "ketcher-core";
-import { Notice, TFile, TextFileView } from "obsidian";
+import { Notice, TextFileView } from "obsidian";
 import React from "react";
 import ReactDOM from "react-dom";
 import KetcherReact from "./KetcherReact";
@@ -8,7 +8,6 @@ export const VIEW_TYPE_KET = "ket-view";
 
 export class KetView extends TextFileView {
 	ketcher: Ketcher;
-	interval: number;
 
 	getViewData() {
 		return this.data;
@@ -57,23 +56,6 @@ export class KetView extends TextFileView {
 		return this.file?.basename ?? "ketcher";
 	}
 
-	async onLoadFile(file: TFile) {
-		window.clearInterval(this.interval);
-		this.interval = window.setInterval(
-			async () => {
-				console.log('save file' + this.file.name);
-				try {
-					this.data = await this.ketcher.getKet();
-					await this.save(); // will call `getViewData`
-					console.log(this.interval)
-				} catch (error) {
-					new Notice(error);
-				}
-			}, 2 * 1000
-		)
-		return super.onLoadFile(file);
-	}
-
 	async onOpen() {
 		this.addAction("save", "Save", async (_eventType) => {
 			try {
@@ -88,6 +70,5 @@ export class KetView extends TextFileView {
 
 	async onClose() {
 		ReactDOM.unmountComponentAtNode(this.containerEl.children[1]);
-		window.clearInterval(this.interval)
 	}
 }

--- a/src/ketView.tsx
+++ b/src/ketView.tsx
@@ -1,5 +1,5 @@
 import { Ketcher } from "ketcher-core";
-import { Notice, TextFileView } from "obsidian";
+import { Notice, TFile, TextFileView } from "obsidian";
 import React from "react";
 import ReactDOM from "react-dom";
 import KetcherReact from "./KetcherReact";
@@ -8,6 +8,7 @@ export const VIEW_TYPE_KET = "ket-view";
 
 export class KetView extends TextFileView {
 	ketcher: Ketcher;
+	interval: number;
 
 	getViewData() {
 		return this.data;
@@ -56,6 +57,23 @@ export class KetView extends TextFileView {
 		return this.file?.basename ?? "ketcher";
 	}
 
+	async onLoadFile(file: TFile) {
+		window.clearInterval(this.interval);
+		this.interval = window.setInterval(
+			async () => {
+				console.log('save file' + this.file.name);
+				try {
+					this.data = await this.ketcher.getKet();
+					await this.save(); // will call `getViewData`
+					console.log(this.interval)
+				} catch (error) {
+					new Notice(error);
+				}
+			}, 2 * 1000
+		)
+		return super.onLoadFile(file);
+	}
+
 	async onOpen() {
 		this.addAction("save", "Save", async (_eventType) => {
 			try {
@@ -70,5 +88,6 @@ export class KetView extends TextFileView {
 
 	async onClose() {
 		ReactDOM.unmountComponentAtNode(this.containerEl.children[1]);
+		window.clearInterval(this.interval)
 	}
 }

--- a/src/ketView.tsx
+++ b/src/ketView.tsx
@@ -30,12 +30,16 @@ export class KetView extends TextFileView {
 							// @ts-ignore
 							global.ketcher = ketcher;
 						}}
+						onChange={async () => {
+							this.data = await this.ketcher.getKet();
+							this.requestSave();
+						}}
 					/>
 				</React.StrictMode>,
 				container
 			);
 		}
-		// Update the same file in other tabs/splits after `save()` is called
+		// Updates the same file in other tabs/splits after `save()` is called
 		else {
 			this.ketcher.setMolecule(this.data);
 		}

--- a/src/ketView.tsx
+++ b/src/ketView.tsx
@@ -61,11 +61,9 @@ export class KetView extends TextFileView {
 		window.clearInterval(this.interval);
 		this.interval = window.setInterval(
 			async () => {
-				console.log('save file' + this.file.name);
 				try {
 					this.data = await this.ketcher.getKet();
 					await this.save(); // will call `getViewData`
-					console.log(this.interval)
 				} catch (error) {
 					new Notice(error);
 				}

--- a/src/ketView.tsx
+++ b/src/ketView.tsx
@@ -61,9 +61,11 @@ export class KetView extends TextFileView {
 		window.clearInterval(this.interval);
 		this.interval = window.setInterval(
 			async () => {
+				console.log('save file' + this.file.name);
 				try {
 					this.data = await this.ketcher.getKet();
 					await this.save(); // will call `getViewData`
+					console.log(this.interval)
 				} catch (error) {
 					new Notice(error);
 				}

--- a/src/ketView.tsx
+++ b/src/ketView.tsx
@@ -41,6 +41,14 @@ export class KetView extends TextFileView {
 		return VIEW_TYPE_KET;
 	}
 
+	getIcon() {
+		return "ketcher";
+	}
+
+	getDisplayText() {
+		return this.file?.basename ?? "ketcher";
+	}
+
 	async onOpen() {
 		this.addAction("save", "Save", async (_eventType) => {
 			try {

--- a/src/ketView.tsx
+++ b/src/ketView.tsx
@@ -8,6 +8,7 @@ export const VIEW_TYPE_KET = "ket-view";
 
 export class KetView extends TextFileView {
 	ketcher: Ketcher;
+	subscriber: any;
 
 	getViewData() {
 		return this.data;
@@ -18,17 +19,19 @@ export class KetView extends TextFileView {
 
 		// If clear is set, then it means we're opening a completely different file.
 		if (_clear) {
+			this.ketcher?.editor.unsubscribe("change", this.subscriber);
 			ReactDOM.unmountComponentAtNode(this.containerEl.children[1]);
 			const container = this.containerEl.children[1];
 			ReactDOM.render(
 				<React.StrictMode>
 					<KetcherReact
 						data={this.data}
-						onInit={(ketcher: Ketcher) => {
+						onInit={(ketcher: Ketcher, subscriber: any) => {
 							this.ketcher = ketcher;
 							// https://github.com/epam/ketcher/issues/2250
 							// @ts-ignore
 							global.ketcher = ketcher;
+							this.subscriber = subscriber;
 						}}
 						onChange={async () => {
 							this.data = await this.ketcher.getKet();
@@ -73,6 +76,7 @@ export class KetView extends TextFileView {
 	}
 
 	async onClose() {
+		this.ketcher.editor.unsubscribe("change", this.subscriber);
 		ReactDOM.unmountComponentAtNode(this.containerEl.children[1]);
 	}
 }

--- a/src/ketView.tsx
+++ b/src/ketView.tsx
@@ -13,26 +13,33 @@ export class KetView extends TextFileView {
 		return this.data;
 	}
 
-	// If clear is set, then it means we're opening a completely different file.
 	setViewData(data: string, _clear: boolean) {
 		this.data = data;
 
-		ReactDOM.unmountComponentAtNode(this.containerEl.children[1]);
-		const container = this.containerEl.children[1];
-		ReactDOM.render(
-			<React.StrictMode>
-				<KetcherReact
-					data={this.data}
-					onInit={(ketcher: Ketcher) => {
-						this.ketcher = ketcher;
-						// https://github.com/epam/ketcher/issues/2250
-						// @ts-ignore
-						global.ketcher = ketcher;
-					}}
-				/>
-			</React.StrictMode>,
-			container
-		);
+		// If clear is set, then it means we're opening a completely different file.
+		if (_clear) {
+			ReactDOM.unmountComponentAtNode(this.containerEl.children[1]);
+			const container = this.containerEl.children[1];
+			ReactDOM.render(
+				<React.StrictMode>
+					<KetcherReact
+						data={this.data}
+						onInit={(ketcher: Ketcher) => {
+							this.ketcher = ketcher;
+							// https://github.com/epam/ketcher/issues/2250
+							// @ts-ignore
+							global.ketcher = ketcher;
+						}}
+					/>
+				</React.StrictMode>,
+				container
+			);
+		}
+		// Update the same file in other tabs/splits after `save()` is called
+		else {
+			this.ketcher.setMolecule(this.data);
+		}
+
 	}
 
 	clear() {}


### PR DESCRIPTION
Closes #2 

**Changes**
- Add icon and explicitly assign file name to the tab header, bdeb76f
- Wrapped render `KetcherReact` in `setViewData()`, 6da45a3
- Set and refresh interval for each file, and clear it in `onClose()`, 17ecb34

**Boundary case**

If we have multiple tabs holding the same file, on proposed, these tabs will each have an interval, and they will run together, calling `save()` more frequently then expected.

Notice that, the `setViewData()` function would only be called by `save()` if there's any change on file data, and the user may probably can't operate multiple editors at the same time, so here's what we'll get:

`Tab A (changed) | Tab B` → `save()` by Tab A → `setViewData()` called → `Tab A (changed) | Tab B (changed)`
`Tab A (changed) | Tab B` → `save()` by Tab B → `setViewData()` won't be called → `Tab A (changed) | Tab B` -> `save()` by Tab A ...

And that's a pseudo-sync maybe.