### PR TITLE
bump to 0.1.3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "ketcher",
 	"name": "Ketcher",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"minAppVersion": "0.1.0",
 	"description": "View or draw chemical structures and reactions using Ketcher.",
 	"author": "Yulei Chen",


### PR DESCRIPTION
In the new 0.1.3 version release, you forgot to bump the manifest.json to 0.1.3. As a result, users of the plugin don't get the new version.